### PR TITLE
Add `bsl.config` system property

### DIFF
--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -251,7 +251,8 @@ public class BootstrapLauncher {
             String key = prop.substring(0, equalsIdx);
             String value = prop.substring(equalsIdx + 1);
 
-            if (!key.isEmpty() && !value.isEmpty())
+            // Only declare the property if it wasn't already declared on JVM startup by the user
+            if (!key.isEmpty() && !value.isEmpty() && System.getProperty(key) == null)
                 System.setProperty(key, value);
         }
     }

--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -52,6 +52,8 @@ public class BootstrapLauncher {
         // Ensure backwards compatibility if somebody reads this value later on.
         System.setProperty("legacyClassPath", String.join(File.pathSeparator, legacyClasspath));
 
+        args = loadConfig(args);
+
         // TODO: find existing modules automatically instead of taking in an ignore list.
         // The ignore list exempts files that start with certain listed keywords from being turned into modules (like existing modules)
         var ignoreList = System.getProperty("ignoreList", "asm,securejarhandler");
@@ -145,8 +147,6 @@ public class BootstrapLauncher {
         var layer = ModuleLayer.defineModules(bootstrapConfiguration, List.of(ModuleLayer.boot()), m -> moduleClassLoader);
         // Set the context class loader to the module class loader from this point forward
         Thread.currentThread().setContextClassLoader(moduleClassLoader);
-
-        args = loadConfig(args);
 
         final var loader = ServiceLoader.load(layer.layer(), Consumer.class);
         // This *should* find the service exposed by ModLauncher's BootstrapLaunchConsumer {This doc is here to help find that class next time we go looking}

--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -260,14 +260,22 @@ public class BootstrapLauncher {
         if (launchArgs == null || launchArgs.isEmpty())
             return inputArgs;
 
-        ArrayList<String> inputArgsList = new ArrayList<>(Arrays.asList(inputArgs));
+        List<String> inputArgsList = new ArrayList<>(Arrays.asList(inputArgs));
+        Set<String> inputArgsKeys = new HashSet<>();
+
+        for (String inputArg : inputArgs) {
+            int equalsIdx = inputArg.indexOf('=');
+            String key = equalsIdx == -1 ? inputArg : inputArg.substring(0, equalsIdx);
+
+            inputArgsKeys.add(key);
+        }
 
         for (String launchArg : launchArgs) {
             int equalsIdx = launchArg.indexOf('=');
             String key = equalsIdx == -1 ? launchArg : launchArg.substring(0, equalsIdx);
 
             // If the input args already contains the key, skip because user args take priority
-            if (!key.isEmpty() && !inputArgsList.contains(key)) {
+            if (!key.isEmpty() && !inputArgsKeys.contains(key)) {
                 inputArgsList.add(launchArg);
             }
         }


### PR DESCRIPTION
This allows declaring system properties and launch args from a file. The application is being able to more easily swap out these values without rebuilding run configurations. However, rebuilding run configurations is still recommended in all cases for best results.

Proper care has been made to ensure that system properties and launch args declared by the user take priority over things declared in the config.
For system properties, the config will only set a system property if it is already unset.
For launch args, all currently passed in args will be parsed in (key=value|key) format. Any keys already passed in will take precedence over any key=value pairs declared in the config. A notable limitation is keys declared using two lines in the config will not support proper overriding by user launch args. This is not possible to remedy given the fact that there is no way to statically tell if a `--key value` grouping actually has the value tied to the key without knowing the parser and options up front (which is not possible). This is not really an issue in most cases, and fixing these cases in forge should cover 99% of cases.