### PR TITLE
Adds an entrypoint for use by JUnit infrastructure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation('cpw.mods:securejarhandler:2.1.2')
+    implementation('cpw.mods:securejarhandler:2.1.24')
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,12 @@ repositories {
 }
 
 dependencies {
+    compileOnly('org.jetbrains:annotations:24.0.1')
     implementation('cpw.mods:securejarhandler:2.1.24')
 }
 
 java {
-    toolchain.languageVersion = JavaLanguageVersion.of(16)
+    toolchain.languageVersion = JavaLanguageVersion.of(17)
     withSourcesJar()
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     compileOnly('org.jetbrains:annotations:24.0.1')
-    implementation('cpw.mods:securejarhandler:2.1.24')
+    implementation('cpw.mods:securejarhandler:2.1.27')
 }
 
 java {

--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.module.Configuration;
 import java.lang.module.ModuleFinder;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,6 +48,11 @@ import java.util.function.Consumer;
 public class BootstrapLauncher {
     private static final boolean DEBUG = System.getProperties().containsKey("bsl.debug");
 
+    /**
+     * This entrypoint is used by the FML junit integration to launch without classloader isolation.
+     * It should not be used for any other purpose. For the consequences of reducing classloader isolation,
+     * read the documentation on {@link ModuleClassLoader#ModuleClassLoader(String, Configuration, List, ClassLoader)}
+     */
     @VisibleForTesting
     public static void unitTestingMain(String... args) {
         System.err.println("*".repeat(80));

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -2,6 +2,7 @@ module cpw.mods.bootstraplauncher {
     uses java.util.function.Consumer;
     requires java.base;
     requires cpw.mods.securejarhandler;
+    requires static org.jetbrains.annotations;
 
     exports cpw.mods.bootstraplauncher;
 }


### PR DESCRIPTION
Depends on https://github.com/McModLauncher/securejarhandler/pull/60

The goal is to add a new entrypoint to BSL for JUnit runners, which disables classloader isolation. This change adds that entrypoint. It is intentionally called `testMain` to prevent it from being used accidentally via the command-line.

This is used to allow test-classes to live in the GAME layer, while still loading JUnit and other testing library classes found on the normal classpath. When being run by a unit testing framework, we do not control the JVM entrypoint like we normally do, and Gradle for example will class-load JUnit before calling any other hook. Our test classes need to refer to those same loaded classes, making it easier if isolation is disabled in such scenarios.
