### PR TITLE
Fail if the legacyClassPath.file does not exist

### DIFF
--- a/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
+++ b/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java
@@ -19,7 +19,6 @@
 package cpw.mods.bootstraplauncher;
 
 import cpw.mods.cl.JarModuleFinder;
-import cpw.mods.cl.ModularURLHandler;
 import cpw.mods.cl.ModuleClassLoader;
 import cpw.mods.jarhandling.SecureJar;
 
@@ -183,19 +182,17 @@ public class BootstrapLauncher {
 
         if (legacyCpPath != null) {
             var legacyCPFileCandidatePath = Paths.get(legacyCpPath);
-            if (Files.exists(legacyCPFileCandidatePath) && Files.isRegularFile(legacyCPFileCandidatePath)) {
-                try {
-                    return Files.readAllLines(legacyCPFileCandidatePath);
-                }
-                catch (IOException e) {
-                    throw new IllegalStateException("Failed to load the legacy class path from the specified file: " + legacyCpPath, e);
-                }
+            try {
+                return Files.readAllLines(legacyCPFileCandidatePath);
+            }
+            catch (IOException e) {
+                throw new IllegalStateException("Failed to load the legacy class path from the specified file: " + legacyCpPath, e);
             }
         }
 
         var legacyClasspath = System.getProperty("legacyClassPath", System.getProperty("java.class.path"));
         Objects.requireNonNull(legacyClasspath, "Missing legacyClassPath, cannot bootstrap");
-        if (legacyClasspath.length() == 0) {
+        if (legacyClasspath.isEmpty()) {
             return List.of();
         } else {
             return Arrays.asList(legacyClasspath.split(File.pathSeparator));


### PR DESCRIPTION
## Motivation

The legacyClassPath is only used in development environments. In production, BSL will fall back to `java.class.path`, since the Minecraft launcher passes all requested libraries and the Minecraft jar on the classpath.

If the file passed in the `legacyClassPath.file` system property exists, BSL falls back to using the `java.class.path`, which is disastrous in dev environment. IDEs put the mods themselves on the class-path too, which leads to BSL converting these mods into modules on the bootstrap layer, causing undecipherable errors when FML later also tries to add the same mods *again* onto a lower layer.

We've had this error multiple times now when the NeoGradle IDE integration failed to properly write the legacyClassPath file before launching, leading to errors such as:

```
Exception in thread "main" java.lang.module.ResolutionException: Modules infiniverse and main export package commoble.infiniverse.internal to module infiniverse_examplemod
```

Or:
```
Exception in thread "main" java.lang.module.ResolutionException: Module creativecore contains package team.creative.creativecore.common, module main exports package team.creative.creativecore.common to creativecore
```

## Change

This change will now error out immediately if the file given as `legacyClassPath.file` does not exist.