### PR TITLE
Remove Manifest attributes not supported when loading through JPMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,12 +37,6 @@ changelog {
 jar {
     manifest {
         attributes(
-                'Specification-Title': 'bootstraplauncher',
-                'Specification-Vendor': 'mcmodlauncher',
-                'Specification-Version': '1', // We are version 1 of ourselves
-                'Implementation-Title': project.name,
-                'Implementation-Version': "${project.version}+${gradleutils.gitInfo.branch}.${gradleutils.gitInfo.abbreviatedId}",
-                'Implementation-Vendor':'mcmodlauncher',
                 'Git-Commit': gradleutils.gitInfo.abbreviatedId,
                 'Git-Branch': gradleutils.gitInfo.branch,
                 'Main-Class': 'cpw.mods.bootstraplauncher.BootstrapLauncher'


### PR DESCRIPTION
Bootstraplauncher will itself always load through the normal JPMS loader, which does not expose these attributes on the package.

While we could keep the attributes, someone might expect these to be available via the Java Package APIs, which they are not.