### PR TITLE
Improve error reporting and dynamically skip files already loaded on module path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,19 +14,20 @@ logger.lifecycle("Version: {}", version)
 
 repositories {
     mavenLocal()
+    mavenCentral()
     maven {
-        name 'forge'
-        url 'https://maven.neoforged.net/releases'
+        name 'NeoForge'
+        url 'https://maven.neoforged.net/releases/'
     }
 }
 
 dependencies {
-    compileOnly('org.jetbrains:annotations:24.0.1')
-    implementation('cpw.mods:securejarhandler:3.0.4')
+    compileOnly('org.jetbrains:annotations:24.1.0')
+    implementation('cpw.mods:securejarhandler:3.0.7')
 }
 
 java {
-    toolchain.languageVersion = JavaLanguageVersion.of(17)
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
     withSourcesJar()
 }
 


### PR DESCRIPTION
This PR will look up which modules are already loaded on the JVM boot layer and record every module with a valid filesystem location. It will then use that information for two purposes:

- Implement a dynamic ignorelist which does not attempt to make modules out of (legacy-)class-path entries if the same filesystem location is already a module on the boot layer
- If the module name of a file on the class-path is already used by a module on the boot layer, but that module has a different filesystem location, report both paths and the module name in an error message

Especially the latter point should provide a much better error experience in case of version conflicts:

```
Exception in thread "main" java.lang.IllegalStateException: Module named JarJarFileSystems was already on the JVMs module path loaded from 
C:\Gradle Home\caches\modules-2\files-2.1\net.neoforged\JarJarFileSystems\0.4.0\ef7e5716525bbe50c784a362f9393457a33e6daf\JarJarFileSystems-0.4.0.jar but class-path contains it at location 
C:\Gradle Home\caches\modules-2\files-2.1\net.neoforged\JarJarFileSystems\0.4.1\78f59f89defcd032ed788b151ca6a0d40ace796a\JarJarFileSystems-0.4.1.jar
```